### PR TITLE
Universal step04

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,5 @@ Bundle.main.localizedString(forKey: self, value: nil, table: table)
 <img width="400" src="https://user-images.githubusercontent.com/38850628/60647008-acdd6c80-9e77-11e9-985d-bdf52ad37123.PNG">
 
 <img width="400" src="https://user-images.githubusercontent.com/38850628/60647166-08a7f580-9e78-11e9-96a8-80da0b3bec68.PNG">
+
+<img width="400" src="https://user-images.githubusercontent.com/38850628/60680936-33219f00-9ec8-11e9-902f-b96430d0defb.gif">

--- a/README.md
+++ b/README.md
@@ -65,3 +65,15 @@ Bundle.main.localizedString(forKey: self, value: nil, table: table)
 <img width="400" src="https://user-images.githubusercontent.com/38850628/60598550-d5b62100-9de7-11e9-8de2-6df1741cca58.png">
 
 <img width="400" src="https://user-images.githubusercontent.com/38850628/60598551-d5b62100-9de7-11e9-90a7-6f361eadae4f.png">
+
+## 23-4. 앱 파편화 - 디바이스/시뮬레이터/iOS 버전
+
+### 배운점
+
+#### Xcode -> Preferences -> Components에서 이전 iOS 버전의 시뮬레이터를 다운받을 수 있다.
+
+### 실행화면
+
+<img width="400" src="https://user-images.githubusercontent.com/38850628/60647008-acdd6c80-9e77-11e9-985d-bdf52ad37123.PNG">
+
+<img width="400" src="https://user-images.githubusercontent.com/38850628/60647166-08a7f580-9e78-11e9-96a8-80da0b3bec68.PNG">

--- a/UniversalApp/UniversalApp.xcodeproj/project.pbxproj
+++ b/UniversalApp/UniversalApp.xcodeproj/project.pbxproj
@@ -401,6 +401,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = JZW6GB7MS9;
 				INFOPLIST_FILE = UniversalApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -418,6 +419,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = JZW6GB7MS9;
 				INFOPLIST_FILE = UniversalApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/UniversalApp/UniversalApp.xcodeproj/project.pbxproj
+++ b/UniversalApp/UniversalApp.xcodeproj/project.pbxproj
@@ -403,6 +403,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = JZW6GB7MS9;
 				INFOPLIST_FILE = UniversalApp/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -421,6 +422,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = JZW6GB7MS9;
 				INFOPLIST_FILE = UniversalApp/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/UniversalApp/UniversalApp/Base.lproj/iPadMain.storyboard
+++ b/UniversalApp/UniversalApp/Base.lproj/iPadMain.storyboard
@@ -24,9 +24,9 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Keanu Charles Reeves" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nZ1-1b-7L7">
-                                <rect key="frame" x="16" y="940.5" width="453" height="53"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="44"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Keanu Charles Reeves" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nZ1-1b-7L7">
+                                <rect key="frame" x="16" y="940.5" width="250.5" height="31.5"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
@@ -47,12 +47,12 @@
                                 <color key="textColor" red="0.30840110780000002" green="0.5618229508" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" textAlignment="justified" lineBreakMode="tailTruncation" numberOfLines="6" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u9Y-xF-Oom">
-                                <rect key="frame" x="16" y="1009.5" width="992" height="340.5"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" textAlignment="justified" lineBreakMode="tailTruncation" numberOfLines="6" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u9Y-xF-Oom">
+                                <rect key="frame" x="16" y="988" width="992" height="362"/>
                                 <string key="text">Movie star. Born in 1964, 54 years old.
 
 The official nationality is Canada. His father is a mixed-race American of native Hawaiians and Chinese, and his mother is British. The birthplace is Lebanon. His father then left his family when Keanu Reeves was three years old, and Keanu Reeves settled with his mother in Canada in 1970. Perhaps because of his father's lineage, he has an Asian feeling for a white actor who works in Hollywood.</string>
-                                <fontDescription key="fontDescription" type="system" pointSize="44"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>

--- a/UniversalApp/UniversalApp/Base.lproj/iPadMain.storyboard
+++ b/UniversalApp/UniversalApp/Base.lproj/iPadMain.storyboard
@@ -30,7 +30,7 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="MDb-Yc-ujD">
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="MDb-Yc-ujD">
                                 <rect key="frame" x="16" y="105" width="992" height="819.5"/>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UxF-th-9t9">

--- a/UniversalApp/UniversalApp/Base.lproj/iPadMain.storyboard
+++ b/UniversalApp/UniversalApp/Base.lproj/iPadMain.storyboard
@@ -80,6 +80,7 @@ The official nationality is Canada. His father is a mixed-race American of nativ
                     </view>
                     <connections>
                         <outlet property="actorImageView" destination="MDb-Yc-ujD" id="9sr-4g-bC5"/>
+                        <outlet property="birthdayButton" destination="UxF-th-9t9" id="KBi-ee-pXl"/>
                         <outlet property="infoLabel" destination="u9Y-xF-Oom" id="uGi-89-ecM"/>
                         <outlet property="languageLabel" destination="mfe-WN-dGT" id="42i-Qm-m4g"/>
                         <outlet property="nameLabel" destination="nZ1-1b-7L7" id="Mey-JX-bYX"/>

--- a/UniversalApp/UniversalApp/Base.lproj/iPhoneMain.storyboard
+++ b/UniversalApp/UniversalApp/Base.lproj/iPhoneMain.storyboard
@@ -72,6 +72,7 @@ The official nationality is Canada. His father is a mixed-race American of nativ
                     </view>
                     <connections>
                         <outlet property="actorImageView" destination="dfD-Z9-hES" id="eWk-7G-VB8"/>
+                        <outlet property="birthdayButton" destination="7SK-JJ-52e" id="Xaw-xV-mcu"/>
                         <outlet property="infoLabel" destination="J8f-sO-e9x" id="KSN-cr-Es8"/>
                         <outlet property="languageLabel" destination="gGG-ZA-Hob" id="kDQ-co-8Bc"/>
                         <outlet property="nameLabel" destination="i8G-Wm-RJo" id="Tyh-Jm-NCK"/>

--- a/UniversalApp/UniversalApp/Base.lproj/iPhoneMain.storyboard
+++ b/UniversalApp/UniversalApp/Base.lproj/iPhoneMain.storyboard
@@ -47,7 +47,7 @@ The official nationality is Canada. His father is a mixed-race American of nativ
                                     <action selector="touchUpInsideBirthdayButton:" destination="d1W-11-pdy" eventType="touchUpInside" id="8Vd-yc-L2W"/>
                                 </connections>
                             </button>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="dfD-Z9-hES">
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="dfD-Z9-hES">
                                 <rect key="frame" x="16" y="79.000000000000028" width="382" height="441.66666666666674"/>
                             </imageView>
                         </subviews>

--- a/UniversalApp/UniversalApp/Base.lproj/iPhoneMain.storyboard
+++ b/UniversalApp/UniversalApp/Base.lproj/iPhoneMain.storyboard
@@ -24,18 +24,18 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Keanu Charles Reeves" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i8G-Wm-RJo">
-                                <rect key="frame" x="16" y="536.66666666666663" width="230" height="27"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Keanu Charles Reeves" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i8G-Wm-RJo">
+                                <rect key="frame" x="16.000000000000014" y="536.66666666666663" width="250.33333333333337" height="31.333333333333371"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J8f-sO-e9x">
-                                <rect key="frame" x="16" y="579.66666666666663" width="382" height="140.33333333333337"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J8f-sO-e9x">
+                                <rect key="frame" x="16" y="584" width="382" height="136"/>
                                 <string key="text">Movie star. Born in 1964, 54 years old.
 
 The official nationality is Canada. His father is a mixed-race American of native Hawaiians and Chinese, and his mother is British. The birthplace is Lebanon. His father then left his family when Keanu Reeves was three years old, and Keanu Reeves settled with his mother in Canada in 1970. Perhaps because of his father's lineage, he has an Asian feeling for a white actor who works in Hollywood.</string>
-                                <fontDescription key="fontDescription" type="system" pointSize="22"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>

--- a/UniversalApp/UniversalApp/ViewController.swift
+++ b/UniversalApp/UniversalApp/ViewController.swift
@@ -31,6 +31,10 @@ class ViewController: UIViewController {
         }
         nameLabel.text = Keys.name.localized
         infoLabel.text = Keys.info.localized
+        
+        #if targetEnvironment(simulator)
+        birthdayButton.isEnabled = false
+        #endif
     }
     
     @IBAction func touchUpInsideBirthdayButton(_ sender: Any) {

--- a/UniversalApp/UniversalApp/ViewController.swift
+++ b/UniversalApp/UniversalApp/ViewController.swift
@@ -14,6 +14,7 @@ class ViewController: UIViewController {
     @IBOutlet weak var languageLabel: UILabel!
     @IBOutlet weak var nameLabel: UILabel!
     @IBOutlet weak var infoLabel: UILabel!
+    @IBOutlet weak var birthdayButton: UIButton!
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/UniversalApp/UniversalApp/ViewController.swift
+++ b/UniversalApp/UniversalApp/ViewController.swift
@@ -24,7 +24,8 @@ class ViewController: UIViewController {
             let language = locale.localizedString(forLanguageCode: languageCode),
             let regionCode = locale.regionCode,
             let region = locale.localizedString(forRegionCode: regionCode) {
-            languageLabel.text = "\(language)\t\(region)"
+            let device = UIDevice.current
+            languageLabel.text = "\(language)\t\(region)\t\(device.systemName)\(device.systemVersion)"
         }
         if let imageName = Keys.imageName.commonLocalized {
             actorImageView.image = UIImage(named: imageName)

--- a/UniversalApp/UniversalApp/ViewController.swift
+++ b/UniversalApp/UniversalApp/ViewController.swift
@@ -35,6 +35,11 @@ class ViewController: UIViewController {
         
         #if targetEnvironment(simulator)
         birthdayButton.isEnabled = false
+        if UIDevice.current.name == "iPhone X" {
+            actorImageView.layer.cornerRadius = 100
+        }
+        #else
+        actorImageView.layer.cornerRadius = 100
         #endif
     }
     

--- a/UniversalApp/UniversalApp/ViewController.swift
+++ b/UniversalApp/UniversalApp/ViewController.swift
@@ -41,6 +41,15 @@ class ViewController: UIViewController {
         #else
         actorImageView.layer.cornerRadius = 100
         #endif
+
+        if #available(iOS 11.0, *) {
+            guard let font = UIFont(name: "Helvetica Neue", size: 17) else { return }
+            let fontMetrics = UIFontMetrics(forTextStyle: .body)
+            infoLabel.font = fontMetrics.scaledFont(for: font)
+        } else {
+            let font = UIFont.systemFont(ofSize: 17)
+            infoLabel.font = font
+        }
     }
     
     @IBAction func touchUpInsideBirthdayButton(_ sender: Any) {

--- a/UniversalApp/UniversalApp/ja.lproj/iPadMain.storyboard
+++ b/UniversalApp/UniversalApp/ja.lproj/iPadMain.storyboard
@@ -80,6 +80,7 @@ The official nationality is Canada. His father is a mixed-race American of nativ
                     </view>
                     <connections>
                         <outlet property="actorImageView" destination="MDb-Yc-ujD" id="9sr-4g-bC5"/>
+                        <outlet property="birthdayButton" destination="UxF-th-9t9" id="WHA-DY-Ha5"/>
                         <outlet property="infoLabel" destination="u9Y-xF-Oom" id="uGi-89-ecM"/>
                         <outlet property="languageLabel" destination="mfe-WN-dGT" id="42i-Qm-m4g"/>
                         <outlet property="nameLabel" destination="nZ1-1b-7L7" id="Mey-JX-bYX"/>

--- a/UniversalApp/UniversalApp/ja.lproj/iPadMain.storyboard
+++ b/UniversalApp/UniversalApp/ja.lproj/iPadMain.storyboard
@@ -24,9 +24,9 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Keanu Charles Reeves" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nZ1-1b-7L7">
-                                <rect key="frame" x="16" y="940.5" width="453" height="53"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="44"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Keanu Charles Reeves" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nZ1-1b-7L7">
+                                <rect key="frame" x="16" y="940.5" width="250.5" height="31.5"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
@@ -47,12 +47,12 @@
                                 <color key="textColor" red="0.30840110780000002" green="0.5618229508" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" textAlignment="justified" lineBreakMode="tailTruncation" numberOfLines="6" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u9Y-xF-Oom">
-                                <rect key="frame" x="16" y="1009.5" width="992" height="340.5"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" textAlignment="justified" lineBreakMode="tailTruncation" numberOfLines="6" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u9Y-xF-Oom">
+                                <rect key="frame" x="16" y="988" width="992" height="362"/>
                                 <string key="text">Movie star. Born in 1964, 54 years old.
 
 The official nationality is Canada. His father is a mixed-race American of native Hawaiians and Chinese, and his mother is British. The birthplace is Lebanon. His father then left his family when Keanu Reeves was three years old, and Keanu Reeves settled with his mother in Canada in 1970. Perhaps because of his father's lineage, he has an Asian feeling for a white actor who works in Hollywood.</string>
-                                <fontDescription key="fontDescription" type="system" pointSize="44"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>

--- a/UniversalApp/UniversalApp/ja.lproj/iPadMain.storyboard
+++ b/UniversalApp/UniversalApp/ja.lproj/iPadMain.storyboard
@@ -30,7 +30,7 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="MDb-Yc-ujD">
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="MDb-Yc-ujD">
                                 <rect key="frame" x="16" y="105" width="992" height="819.5"/>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UxF-th-9t9">

--- a/UniversalApp/UniversalApp/ja.lproj/iPhoneMain.storyboard
+++ b/UniversalApp/UniversalApp/ja.lproj/iPhoneMain.storyboard
@@ -72,6 +72,7 @@ The official nationality is Canada. His father is a mixed-race American of nativ
                     </view>
                     <connections>
                         <outlet property="actorImageView" destination="dfD-Z9-hES" id="eWk-7G-VB8"/>
+                        <outlet property="birthdayButton" destination="7SK-JJ-52e" id="nzT-Rw-tcT"/>
                         <outlet property="infoLabel" destination="J8f-sO-e9x" id="KSN-cr-Es8"/>
                         <outlet property="languageLabel" destination="gGG-ZA-Hob" id="kDQ-co-8Bc"/>
                         <outlet property="nameLabel" destination="i8G-Wm-RJo" id="Tyh-Jm-NCK"/>

--- a/UniversalApp/UniversalApp/ja.lproj/iPhoneMain.storyboard
+++ b/UniversalApp/UniversalApp/ja.lproj/iPhoneMain.storyboard
@@ -24,18 +24,18 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Keanu Charles Reeves" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i8G-Wm-RJo">
-                                <rect key="frame" x="16" y="536.66666666666663" width="230" height="27"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Keanu Charles Reeves" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i8G-Wm-RJo">
+                                <rect key="frame" x="16.000000000000014" y="536.66666666666663" width="250.33333333333337" height="31.333333333333371"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J8f-sO-e9x">
-                                <rect key="frame" x="16" y="579.66666666666663" width="382" height="140.33333333333337"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J8f-sO-e9x">
+                                <rect key="frame" x="16" y="584" width="382" height="136"/>
                                 <string key="text">Movie star. Born in 1964, 54 years old.
 
 The official nationality is Canada. His father is a mixed-race American of native Hawaiians and Chinese, and his mother is British. The birthplace is Lebanon. His father then left his family when Keanu Reeves was three years old, and Keanu Reeves settled with his mother in Canada in 1970. Perhaps because of his father's lineage, he has an Asian feeling for a white actor who works in Hollywood.</string>
-                                <fontDescription key="fontDescription" type="system" pointSize="22"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>

--- a/UniversalApp/UniversalApp/ja.lproj/iPhoneMain.storyboard
+++ b/UniversalApp/UniversalApp/ja.lproj/iPhoneMain.storyboard
@@ -47,7 +47,7 @@ The official nationality is Canada. His father is a mixed-race American of nativ
                                     <action selector="touchUpInsideBirthdayButton:" destination="d1W-11-pdy" eventType="touchUpInside" id="aEn-hE-Ezq"/>
                                 </connections>
                             </button>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="dfD-Z9-hES">
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="dfD-Z9-hES">
                                 <rect key="frame" x="16" y="79.000000000000028" width="382" height="441.66666666666674"/>
                             </imageView>
                         </subviews>

--- a/UniversalApp/UniversalApp/ko.lproj/iPadMain.storyboard
+++ b/UniversalApp/UniversalApp/ko.lproj/iPadMain.storyboard
@@ -24,9 +24,9 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Keanu Charles Reeves" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nZ1-1b-7L7">
-                                <rect key="frame" x="16" y="940.5" width="453" height="53"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="44"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Keanu Charles Reeves" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nZ1-1b-7L7">
+                                <rect key="frame" x="16" y="940.5" width="250.5" height="31.5"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
@@ -47,12 +47,12 @@
                                 <color key="textColor" red="0.30840110780000002" green="0.5618229508" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" textAlignment="justified" lineBreakMode="tailTruncation" numberOfLines="6" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u9Y-xF-Oom">
-                                <rect key="frame" x="16" y="1009.5" width="992" height="340.5"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" textAlignment="justified" lineBreakMode="tailTruncation" numberOfLines="6" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u9Y-xF-Oom">
+                                <rect key="frame" x="16" y="988" width="992" height="362"/>
                                 <string key="text">Movie star. Born in 1964, 54 years old.
 
 The official nationality is Canada. His father is a mixed-race American of native Hawaiians and Chinese, and his mother is British. The birthplace is Lebanon. His father then left his family when Keanu Reeves was three years old, and Keanu Reeves settled with his mother in Canada in 1970. Perhaps because of his father's lineage, he has an Asian feeling for a white actor who works in Hollywood.</string>
-                                <fontDescription key="fontDescription" type="system" pointSize="44"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>

--- a/UniversalApp/UniversalApp/ko.lproj/iPadMain.storyboard
+++ b/UniversalApp/UniversalApp/ko.lproj/iPadMain.storyboard
@@ -80,6 +80,7 @@ The official nationality is Canada. His father is a mixed-race American of nativ
                     </view>
                     <connections>
                         <outlet property="actorImageView" destination="MDb-Yc-ujD" id="9sr-4g-bC5"/>
+                        <outlet property="birthdayButton" destination="UxF-th-9t9" id="g27-nn-6FI"/>
                         <outlet property="infoLabel" destination="u9Y-xF-Oom" id="uGi-89-ecM"/>
                         <outlet property="languageLabel" destination="mfe-WN-dGT" id="42i-Qm-m4g"/>
                         <outlet property="nameLabel" destination="nZ1-1b-7L7" id="Mey-JX-bYX"/>

--- a/UniversalApp/UniversalApp/ko.lproj/iPadMain.storyboard
+++ b/UniversalApp/UniversalApp/ko.lproj/iPadMain.storyboard
@@ -30,7 +30,7 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="MDb-Yc-ujD">
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="MDb-Yc-ujD">
                                 <rect key="frame" x="16" y="105" width="992" height="819.5"/>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UxF-th-9t9">

--- a/UniversalApp/UniversalApp/ko.lproj/iPhoneMain.storyboard
+++ b/UniversalApp/UniversalApp/ko.lproj/iPhoneMain.storyboard
@@ -47,7 +47,7 @@ The official nationality is Canada. His father is a mixed-race American of nativ
                                     <action selector="touchUpInsideBirthdayButton:" destination="d1W-11-pdy" eventType="touchUpInside" id="iTx-UJ-i3P"/>
                                 </connections>
                             </button>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="dfD-Z9-hES">
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="dfD-Z9-hES">
                                 <rect key="frame" x="16" y="79.000000000000028" width="382" height="441.66666666666674"/>
                             </imageView>
                         </subviews>

--- a/UniversalApp/UniversalApp/ko.lproj/iPhoneMain.storyboard
+++ b/UniversalApp/UniversalApp/ko.lproj/iPhoneMain.storyboard
@@ -24,18 +24,18 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Keanu Charles Reeves" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i8G-Wm-RJo">
-                                <rect key="frame" x="16" y="536.66666666666663" width="230" height="27"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Keanu Charles Reeves" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i8G-Wm-RJo">
+                                <rect key="frame" x="16.000000000000014" y="536.66666666666663" width="250.33333333333337" height="31.333333333333371"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J8f-sO-e9x">
-                                <rect key="frame" x="16" y="579.66666666666663" width="382" height="140.33333333333337"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J8f-sO-e9x">
+                                <rect key="frame" x="16" y="584" width="382" height="136"/>
                                 <string key="text">Movie star. Born in 1964, 54 years old.
 
 The official nationality is Canada. His father is a mixed-race American of native Hawaiians and Chinese, and his mother is British. The birthplace is Lebanon. His father then left his family when Keanu Reeves was three years old, and Keanu Reeves settled with his mother in Canada in 1970. Perhaps because of his father's lineage, he has an Asian feeling for a white actor who works in Hollywood.</string>
-                                <fontDescription key="fontDescription" type="system" pointSize="22"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>

--- a/UniversalApp/UniversalApp/ko.lproj/iPhoneMain.storyboard
+++ b/UniversalApp/UniversalApp/ko.lproj/iPhoneMain.storyboard
@@ -72,6 +72,7 @@ The official nationality is Canada. His father is a mixed-race American of nativ
                     </view>
                     <connections>
                         <outlet property="actorImageView" destination="dfD-Z9-hES" id="eWk-7G-VB8"/>
+                        <outlet property="birthdayButton" destination="7SK-JJ-52e" id="Q0F-XA-ZqO"/>
                         <outlet property="infoLabel" destination="J8f-sO-e9x" id="KSN-cr-Es8"/>
                         <outlet property="languageLabel" destination="gGG-ZA-Hob" id="kDQ-co-8Bc"/>
                         <outlet property="nameLabel" destination="i8G-Wm-RJo" id="Tyh-Jm-NCK"/>


### PR DESCRIPTION
### 작업내용

- 시뮬레이터인 경우는 [생일버튼]을 비활성화해서 누르지 못하게 하고 실제 폰인 경우에만 활성화하도록 했습니다.
- 언어/지역 옆에 디바이스 시스템 타입을 표기했습니다.
- 이름과 설명 레이블에 Dynamic Type을 적용하고 시스템 설정에 따라 바뀌는지 확인했습니다.
- 아이폰 X 시뮬레이터나 디바이스인 경우에만, 해당 배우 사진을 모서리를 동그렇게 처리했습니다.
- 앱 Deployment Target을 10.0 이상으로 낮추고 descriptionLabel 글꼴을 Helvetica Neue 로 적용했습니다.
- iOS 11.0 이상인 경우 UIFontMetrics에서 scaledFont 기능을 활용해서 만들고 그 이하인 경우는 systemFont를 사용하도록 했습니다.